### PR TITLE
Temporary workaround for ghc-mod type missing type class info.

### DIFF
--- a/lib/ghc-mod/ghc-modi-process.coffee
+++ b/lib/ghc-mod/ghc-modi-process.coffee
@@ -185,6 +185,25 @@ class GhcModiProcess
           symbolType = 'function'
         {name, typeSignature, symbolType}
 
+  getTypeInBufferForInsert: (editor, crange) =>
+    buffer = editor.getBuffer()
+    {symbol, range} = Util.getSymbolInRange(editor, crange)
+
+    @queueCmd 'typeinfo',
+      interactive: true
+      buffer: buffer
+      command: 'info',
+      uri: buffer.getUri()
+      text: buffer.getText() if buffer.isModified()
+      args: [symbol]
+    .then (lines) ->
+      info = lines.join(EOL)
+      if info is 'Cannot show info' or not info
+        throw new Error "No type"
+      else
+        type = info.split("--")[0].split("::")[1].trim()
+        return {range, type}
+
   getTypeInBuffer: (buffer, crange) =>
     @queueCmd 'typeinfo',
       interactive: true

--- a/lib/haskell-ghc-mod.coffee
+++ b/lib/haskell-ghc-mod.coffee
@@ -169,7 +169,7 @@ module.exports = HaskellGhcMod =
         Util = require './util'
         editor = target.getModel()
         upi.withEventRange {editor, detail}, ({crange}) =>
-          @process.getTypeInBuffer(editor.getBuffer(), crange)
+          @process.getTypeInBufferForInsert(editor, crange)
           .then (o) ->
             {type} = o
             n = editor.indentationForBufferRow(o.range.start.row)


### PR DESCRIPTION
This is a hack to allow insert type to insert proper type class info with versions of ghc-mod that have a bug when using the 'type' command. Not sure if you are interested in putting hacks into the code base but I thought I'd throw it out for your review. Feel free to ignore.