### PR TITLE
Add go-to-declaration to keymap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can edit Atom keybindings by opening 'Edit → Open Your Keymap'. Here is a 
   'ctrl-alt-T': 'haskell-ghc-mod:insert-type' #this is an example binding
   '': 'haskell-ghc-mod:show-info-fallback-to-type'
   '': 'haskell-ghc-mod:insert-import'
+  '': 'haskell-ghc-mod:go-to-declaration'
 
 'atom-workspace':
   '': 'haskell-ghc-mod:shutdown-backend'


### PR DESCRIPTION
This is a follow-up of https://github.com/atom-haskell/ide-haskell/issues/137
I could not find this command in menus, so it's worth mentioning it in keymap example at least.