### PR TITLE
Consistent environment

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -6,6 +6,7 @@ CP = require('child_process')
 {EOL} = require('os')
 HsUtil = require 'atom-haskell-utils'
 objclone = require 'clone'
+{consistentEnv} = require 'consistent-env';
 
 debuglog = []
 logKeep = 30000 #ms
@@ -54,7 +55,7 @@ module.exports = Util =
       return res.join(delimiter)
     Util.debug "getProcessOptions(#{rootPath})"
     env = {}
-    for k, v of process.env
+    for k, v of consistentEnv()
       env[k] = v
     apd = atom.config.get('haskell-ghc-mod.additionalPathDirectories')
           .concat process.env.PATH.split delimiter

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -6,7 +6,7 @@ CP = require('child_process')
 {EOL} = require('os')
 HsUtil = require 'atom-haskell-utils'
 objclone = require 'clone'
-{consistentEnv} = require 'consistent-env';
+consistentEnv = require 'consistent-env';
 
 debuglog = []
 logKeep = 30000 #ms

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -69,7 +69,7 @@ module.exports = Util =
             sbd = true
             apd.unshift sandbox
       if atom.config.get('haskell-ghc-mod.stackSandbox')
-        env.PATH = joinPath(apd)
+        env.PATH = joinPath(apd) if env.PATH == ''
         stackpath =
           try CP.execSync "stack path --bin-path",
             encoding: 'utf-8'
@@ -79,7 +79,7 @@ module.exports = Util =
           apd = stackpath.split(delimiter).concat apd
         if sbd
           apd.unshift sandbox
-    env.PATH = joinPath(apd)
+    env.PATH = joinPath(apd) if env.PATH == ''
     Util.debug "PATH = #{env.PATH}"
     options =
       cwd: rootPath

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "promise-queue": "^2.2.0",
     "atom-space-pen-views": "^2.0.3",
     "atom-haskell-utils": "^0.7.1",
-    "clone": "^1.0.2"
+    "clone": "^1.0.2",
+    "consistent-env": "^1.0.0"
   },
   "consumedServices": {
     "ide-haskell-upi": {


### PR DESCRIPTION
This PR uses the [`consistent-env`](https://github.com/steelbrain/consistent-env) module to avoid needing to set up the `PATH` variable (and the rest of the environment) in `haskell-ghc-mod`.

This resolves certain issues where subtly different environments between the CLI and `haskell-ghc-mod` causes `stack` to endlessly build and rebuild.