### PR TITLE
Exposed max buffer size as setting.

### DIFF
--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -153,6 +153,7 @@ module.exports = Util =
           cwd: rootPath
           env: env
           encoding: 'utf-8'
+          maxBuffer: Infinity
         }
     @processOptionsCache.set(rootPath, res)
     return res


### PR DESCRIPTION
I hit an issue where the spawned process was exceeding the max buffer size. I was able to fix this error by setting `maxBuffer: Infinity` in the options passed to the child process.

I have exposed this `maxBuffer` option as a setting and defaulted it to `Number.MAX_VALUE` (since atom won't display `Infinity`).